### PR TITLE
Fix errors

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -10,6 +10,9 @@ MRuby::Gem::Specification.new('mruby-rspec') do |spec|
 
   spec.test_rbfiles = Dir.glob("#{dir}/spec/**/*_spec.rb")
 
+  # Required for #send method
+  spec.add_dependency('mruby-metaprog', :core => 'mruby-metaprog')
+
   # Required to print test errors
   spec.add_dependency('mruby-print', :core => 'mruby-print')
 end

--- a/mrblib/example.rb
+++ b/mrblib/example.rb
@@ -2,16 +2,19 @@ module RSpec
   class Example
     include RSpec::Matchers::DSL
 
-    PENDING = -> { raise MRubyTestSkip, "(Not implemented)" }
     def initialize(group,description,&block)
       @group = group
       @description = description
-      @block = block || PENDING
+      @block = block
     end
 
     # Executes the example Proc
     def execute
-      instance_eval(&@block)
+      if @block
+        instance_eval(&@block)
+      else
+        raise MRubyTestSkip, "(Not implemented)"
+      end
     end
 
     # The example full description


### PR DESCRIPTION
- Add mruby-metaprog as dependency
  - Required for `#send` method
- Fix "wrong number of arguments" error
  - Lambdas check arg count, so avoid creating one